### PR TITLE
Moved Net::Ftp::Version to Net::FTP

### DIFF
--- a/lib/net/ftp.rb
+++ b/lib/net/ftp.rb
@@ -85,6 +85,7 @@ module Net
     end
 
     # :stopdoc:
+    VERSION = "0.1.0"
     FTP_PORT = 21
     CRLF = "\r\n"
     DEFAULT_BLOCKSIZE = BufferedIO::BUFSIZE

--- a/lib/net/ftp/version.rb
+++ b/lib/net/ftp/version.rb
@@ -1,5 +1,0 @@
-module Net
-  module Ftp
-    VERSION = "0.1.0"
-  end
-end

--- a/net-ftp.gemspec
+++ b/net-ftp.gemspec
@@ -1,12 +1,14 @@
-begin
-  require_relative 'lib/net/ftp/version'
-rescue LoadError # Fallback to load version file in ruby core repository
-  require_relative "version"
+name = File.basename(__FILE__, ".gemspec")
+version = nil
+["lib", "../.."].find do |dir|
+  version = File.foreach(File.join(__dir__, dir, "#{name.tr('-', '/')}.rb")) do |line|
+    /^\s*VERSION\s*=\s*"(.*)"/ =~ line and break $1
+  end rescue nil
 end
 
 Gem::Specification.new do |spec|
   spec.name          = "net-ftp"
-  spec.version       = Net::Ftp::VERSION
+  spec.version       = version
   spec.authors       = ["Shugo Maeda"]
   spec.email         = ["shugo@ruby-lang.org"]
 


### PR DESCRIPTION
On case-insensitive filesystem, generated Net/FTP.html is overwritten by Net/Ftp.html.