### PR TITLE
Replace "iff" with "if and only if"

### DIFF
--- a/lib/net/ftp.rb
+++ b/lib/net/ftp.rb
@@ -1356,7 +1356,7 @@ module Net
     end
 
     #
-    # Returns +true+ iff the connection is closed.
+    # Returns +true+ if and only if the connection is closed.
     #
     def closed?
       @sock == nil or @sock.closed?


### PR DESCRIPTION
iff means if and only if, but readers without that knowledge might
assume this to be a spelling mistake. To me, this seems like
exclusionary language that is unnecessary. Simply using "if and only if"
instead should suffice.

net-ftp changes from https://github.com/ruby/ruby/pull/4035