### PR TITLE
test/net/ftp/test_ftp.rb: Use suitable MJIT constant.

### DIFF
--- a/test/net/ftp/test_ftp.rb
+++ b/test/net/ftp/test_ftp.rb
@@ -19,6 +19,10 @@ class FTPTest < Test::Unit::TestCase
   SERVER_KEY = File.expand_path("../fixtures/server.key", __dir__)
   SERVER_CERT = File.expand_path("../fixtures/server.crt", __dir__)
 
+  def mjit_enabled?
+    (defined?(RubyVM::JIT) && RubyVM::JIT.enabled?) or (defined?(RubyVM::MJIT) && RubyVM::MJIT.enabled?)
+  end
+
   def setup
     @thread = nil
     @default_passive = Net::FTP.default_passive
@@ -762,7 +766,7 @@ class FTPTest < Test::Unit::TestCase
     begin
       begin
         ftp = Net::FTP.new
-        ftp.read_timeout *= 5 if defined?(RubyVM::JIT) && RubyVM::JIT.enabled? # for --jit-wait
+        ftp.read_timeout *= 5 if mjit_enabled? # for --jit-wait
         ftp.connect(SERVER_ADDR, server.port)
         ftp.login
         assert_match(/\AUSER /, commands.shift)
@@ -807,7 +811,7 @@ class FTPTest < Test::Unit::TestCase
     begin
       begin
         ftp = Net::FTP.new
-        ftp.read_timeout *= 5 if defined?(RubyVM::JIT) && RubyVM::JIT.enabled? # for --jit-wait
+        ftp.read_timeout *= 5 if mjit_enabled? # for --jit-wait
         ftp.connect(SERVER_ADDR, server.port)
         ftp.login
         assert_match(/\AUSER /, commands.shift)
@@ -900,7 +904,7 @@ class FTPTest < Test::Unit::TestCase
       begin
         ftp = Net::FTP.new
         ftp.passive = true
-        ftp.read_timeout *= 5 if defined?(RubyVM::JIT) && RubyVM::JIT.enabled? # for --jit-wait
+        ftp.read_timeout *= 5 if mjit_enabled? # for --jit-wait
         ftp.connect(SERVER_ADDR, server.port)
         ftp.login
         assert_match(/\AUSER /, commands.shift)
@@ -1579,7 +1583,7 @@ EOF
     begin
       begin
         ftp = Net::FTP.new
-        ftp.read_timeout *= 5 if defined?(RubyVM::JIT) && RubyVM::JIT.enabled? # for --jit-wait
+        ftp.read_timeout *= 5 if mjit_enabled? # for --jit-wait
         ftp.connect(SERVER_ADDR, server.port)
         assert_equal(['LANG EN*', 'UTF8'], ftp.features)
         assert_equal("FEAT\r\n", commands.shift)
@@ -1602,7 +1606,7 @@ EOF
     begin
       begin
         ftp = Net::FTP.new
-        ftp.read_timeout *= 5 if defined?(RubyVM::JIT) && RubyVM::JIT.enabled? # for --jit-wait
+        ftp.read_timeout *= 5 if mjit_enabled? # for --jit-wait
         ftp.connect(SERVER_ADDR, server.port)
         assert_raise(Net::FTPPermError) do
           ftp.features
@@ -1628,7 +1632,7 @@ EOF
     begin
       begin
         ftp = Net::FTP.new
-        ftp.read_timeout *= 5 if defined?(RubyVM::JIT) && RubyVM::JIT.enabled? # for --jit-wait
+        ftp.read_timeout *= 5 if mjit_enabled? # for --jit-wait
         ftp.connect(SERVER_ADDR, server.port)
         ftp.option("UTF8", "ON")
         assert_equal("OPTS UTF8 ON\r\n", commands.shift)
@@ -1687,7 +1691,7 @@ EOF
     begin
       begin
         ftp = Net::FTP.new
-        ftp.read_timeout *= 5 if defined?(RubyVM::JIT) && RubyVM::JIT.enabled? # for --jit-wait
+        ftp.read_timeout *= 5 if mjit_enabled? # for --jit-wait
         ftp.connect(SERVER_ADDR, server.port)
         entry = ftp.mlst("foo")
         assert_equal("/foo", entry.pathname)
@@ -1774,7 +1778,7 @@ EOF
     begin
       begin
         ftp = Net::FTP.new
-        ftp.read_timeout *= 5 if defined?(RubyVM::JIT) && RubyVM::JIT.enabled? # for --jit-wait
+        ftp.read_timeout *= 5 if mjit_enabled? # for --jit-wait
         ftp.connect(SERVER_ADDR, server.port)
         ftp.login
         assert_match(/\AUSER /, commands.shift)
@@ -1813,7 +1817,7 @@ EOF
 
   def test_parse257
     ftp = Net::FTP.new
-    ftp.read_timeout *= 5 if defined?(RubyVM::JIT) && RubyVM::JIT.enabled? # for --jit-wait
+    ftp.read_timeout *= 5 if mjit_enabled? # for --jit-wait
     assert_equal('/foo/bar',
                  ftp.send(:parse257, '257 "/foo/bar" directory created'))
     assert_equal('/foo/bar"baz',
@@ -1952,7 +1956,7 @@ EOF
                          port: port,
                          ssl: { ca_file: CA_FILE },
                          passive: false)
-      ftp.read_timeout *= 5 if defined?(RubyVM::JIT) && RubyVM::JIT.enabled? # for --jit-wait
+      ftp.read_timeout *= 5 if mjit_enabled? # for --jit-wait
       begin
         assert_equal("AUTH TLS\r\n", commands.shift)
         assert_equal("PBSZ 0\r\n", commands.shift)
@@ -2037,7 +2041,7 @@ EOF
                          port: port,
                          ssl: { ca_file: CA_FILE },
                          passive: true)
-      ftp.read_timeout *= 5 if defined?(RubyVM::JIT) && RubyVM::JIT.enabled? # for --jit-wait
+      ftp.read_timeout *= 5 if mjit_enabled? # for --jit-wait
       begin
         assert_equal("AUTH TLS\r\n", commands.shift)
         assert_equal("PBSZ 0\r\n", commands.shift)
@@ -2113,7 +2117,7 @@ EOF
                          ssl: { ca_file: CA_FILE },
                          private_data_connection: false,
                          passive: false)
-      ftp.read_timeout *= 5 if defined?(RubyVM::JIT) && RubyVM::JIT.enabled? # for --jit-wait
+      ftp.read_timeout *= 5 if mjit_enabled? # for --jit-wait
       begin
         assert_equal("AUTH TLS\r\n", commands.shift)
         ftp.login
@@ -2183,7 +2187,7 @@ EOF
                          ssl: { ca_file: CA_FILE },
                          private_data_connection: false,
                          passive: true)
-      ftp.read_timeout *= 5 if defined?(RubyVM::JIT) && RubyVM::JIT.enabled? # for --jit-wait
+      ftp.read_timeout *= 5 if mjit_enabled? # for --jit-wait
       begin
         assert_equal("AUTH TLS\r\n", commands.shift)
         ftp.login
@@ -2264,7 +2268,7 @@ EOF
         ftp = Net::FTP.new(SERVER_NAME,
                            port: server.port,
                            ssl: { ca_file: CA_FILE })
-        ftp.read_timeout *= 5 if defined?(RubyVM::JIT) && RubyVM::JIT.enabled? # for --jit-wait
+        ftp.read_timeout *= 5 if mjit_enabled? # for --jit-wait
         assert_equal("AUTH TLS\r\n", commands.shift)
         assert_equal("PBSZ 0\r\n", commands.shift)
         assert_equal("PROT P\r\n", commands.shift)
@@ -2317,7 +2321,7 @@ EOF
           begin
             ftp = Net::FTP.new
             ftp.resume = resume
-            ftp.read_timeout = (defined?(RubyVM::JIT) && RubyVM::JIT.enabled?) ? 300 : 0.2 # use large timeout for --jit-wait
+            ftp.read_timeout = (mjit_enabled?) ? 300 : 0.2 # use large timeout for --jit-wait
             ftp.connect(SERVER_ADDR, server.port)
             ftp.login
             assert_match(/\AUSER /, commands.shift)
@@ -2376,7 +2380,7 @@ EOF
       chdir_to_tmpdir do
         begin
           ftp = Net::FTP.new
-          ftp.read_timeout *= 5 if defined?(RubyVM::JIT) && RubyVM::JIT.enabled? # for --jit-wait
+          ftp.read_timeout *= 5 if mjit_enabled? # for --jit-wait
           ftp.connect(SERVER_ADDR, server.port)
           ftp.login
           assert_match(/\AUSER /, commands.shift)
@@ -2427,7 +2431,7 @@ EOF
         File.binwrite("./|echo hello", binary_data)
         begin
           ftp = Net::FTP.new
-          ftp.read_timeout = defined?(RubyVM::JIT) && RubyVM::JIT.enabled? ? 300 : 0.2 # use large timeout for --jit-wait
+          ftp.read_timeout = mjit_enabled? ? 300 : 0.2 # use large timeout for --jit-wait
           ftp.connect(SERVER_ADDR, server.port)
           ftp.login
           assert_match(/\AUSER /, commands.shift)
@@ -2482,7 +2486,7 @@ EOF
         end
         begin
           ftp = Net::FTP.new
-          ftp.read_timeout *= 5 if defined?(RubyVM::JIT) && RubyVM::JIT.enabled? # for --jit-wait
+          ftp.read_timeout *= 5 if mjit_enabled? # for --jit-wait
           ftp.connect(SERVER_ADDR, server.port)
           ftp.login
           assert_match(/\AUSER /, commands.shift)


### PR DESCRIPTION
On ruby 2.7/3.0, the constant for MJIT was named RubyVM::MJIT.

This PR introduce utility method to check suitable constants.