### PR TITLE
Allow setting debug output stream for FTP connections

### DIFF
--- a/test/net/ftp/test_ftp.rb
+++ b/test/net/ftp/test_ftp.rb
@@ -2654,19 +2654,19 @@ EOF
   end
 
   def test_debug_print
-    debug_stream = StringIO.new
+    [StringIO.new, Tempfile.new].each do |debug_stream|
+      ftp = Net::FTP.new
+      ftp.debug_output = debug_stream
 
-    ftp = Net::FTP.new
-    ftp.debug_output = debug_stream
+      ftp.debug_print("Test")
+      debug_stream.rewind
+      assert_equal(debug_stream.read, "")
 
-    ftp.debug_print("Test")
-    debug_stream.rewind
-    assert_equal(debug_stream.read, "")
-
-    ftp.debug_mode = true
-    ftp.debug_print("Test")
-    debug_stream.rewind
-    assert_equal(debug_stream.read, "Test\n")
+      ftp.debug_mode = true
+      ftp.debug_print("Test")
+      debug_stream.rewind
+      assert_equal(debug_stream.read, "Test\n")
+    end
   end
 
   private

--- a/test/net/ftp/test_ftp.rb
+++ b/test/net/ftp/test_ftp.rb
@@ -2653,6 +2653,22 @@ EOF
     end
   end
 
+  def test_debug_print
+    debug_stream = StringIO.new
+
+    ftp = Net::FTP.new
+    ftp.debug_output = debug_stream
+
+    ftp.debug_print("Test")
+    debug_stream.rewind
+    assert_equal(debug_stream.read, "")
+
+    ftp.debug_mode = true
+    ftp.debug_print("Test")
+    debug_stream.rewind
+    assert_equal(debug_stream.read, "Test\n")
+  end
+
   private
 
   def create_ftp_server(sleep_time = nil, addr = SERVER_ADDR)


### PR DESCRIPTION
**NOTE: PR from original work here https://github.com/ruby/ruby/pull/2235**

This PR adds support for setting a custom debug stream output on Net::FTP connections.

Other Net stdlib classes already offer this feature so lets close the gap and make it easier for devs to capture debug logs from Net::FTP.  Change is made with backwards support, so $stdout is still the default output stream if it's enabled. 

Example use case:

```ruby
require "net/ftp"

log = StringIO.new

conn = Net::FTP.new(...)
conn.debug_mode = true
conn.debug_output = log
# do the thing

log.rewind
puts log.read
```