### PR TITLE
Drop unused directives in gemspec

### DIFF
--- a/net-ftp.gemspec
+++ b/net-ftp.gemspec
@@ -27,8 +27,6 @@ Gem::Specification.new do |spec|
   spec.files         = Dir.chdir(File.expand_path('..', __FILE__)) do
     `git ls-files -z 2>/dev/null`.split("\x0").reject { |f| f.match(%r{^(bin|test|spec|features)/}) }
   end
-  spec.bindir        = "exe"
-  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
   spec.add_dependency "net-protocol"


### PR DESCRIPTION
This gem exposes no executables. This PR removes the configuration for that in the gemspec.