### PR TITLE
Revert "Replace Timeout.timeout with socket timeout"

### DIFF
--- a/lib/net/ftp.rb
+++ b/lib/net/ftp.rb
@@ -356,19 +356,14 @@ module Net
     # SOCKS_SERVER, then a SOCKSSocket is returned, else a Socket is
     # returned.
     def open_socket(host, port) # :nodoc:
-      if defined? SOCKSSocket and ENV["SOCKS_SERVER"]
-        @passive = true
-        Timeout.timeout(@open_timeout, OpenTimeout) do
+      return Timeout.timeout(@open_timeout, OpenTimeout) {
+        if defined? SOCKSSocket and ENV["SOCKS_SERVER"]
+          @passive = true
           SOCKSSocket.open(host, port)
+        else
+          Socket.tcp(host, port)
         end
-      else
-        begin
-          Socket.tcp host, port, nil, nil, connect_timeout: @open_timeout
-        rescue Errno::ETIMEDOUT #raise Net:OpenTimeout instead for compatibility with previous versions
-          raise Net::OpenTimeout, "Timeout to open TCP connection to "\
-          "#{host}:#{port} (exceeds #{@open_timeout} seconds)"
-        end
-      end
+      }
     end
     private :open_socket
 


### PR DESCRIPTION
Reverts ruby/net-ftp#5

Same reason with https://github.com/ruby/net-http/pull/74