### PR TITLE
Use `assert_raises` instead of `assert_raise` for SocketError

### DIFF
--- a/test/net/ftp/test_ftp.rb
+++ b/test/net/ftp/test_ftp.rb
@@ -2642,7 +2642,7 @@ EOF
         assert_match(/\AUSER /, commands.shift)
         assert_match(/\APASS /, commands.shift)
         assert_equal("TYPE I\r\n", commands.shift)
-        assert_raise(SocketError) do
+        assert_raises(SocketError) do
           ftp.getbinaryfile("foo", nil)
         end
       ensure


### PR DESCRIPTION
The following PR changes cause `Socket::ResolutionError`, a subclass of `SocketError`, to be raised in this test case. https://github.com/ruby/ruby/pull/9018

While `assert_raise` verifies that the error being raised is indeed a `SocketError`, `assert_raises` can verify that it is a SocketError or a subclass thereof. It will avoid unwanted test failures.