### PR TITLE
Fall back to SocketError unless Socket::ResolutionError is defined

### DIFF
--- a/test/net/ftp/test_ftp.rb
+++ b/test/net/ftp/test_ftp.rb
@@ -2642,7 +2642,9 @@ EOF
         assert_match(/\AUSER /, commands.shift)
         assert_match(/\APASS /, commands.shift)
         assert_equal("TYPE I\r\n", commands.shift)
-        assert_raise(SocketError) do
+
+        error_klass = defined?(Socket::ResolutionError) ? Socket::ResolutionError : SocketError
+        assert_raise(error_klass) do
           ftp.getbinaryfile("foo", nil)
         end
       ensure


### PR DESCRIPTION
The following PR changes cause Socket::ResolutionError, a subclass of SocketError, to be raised in this test case. https://github.com/ruby/ruby/pull/9018
In this repository, make it fall back to SocketError if it is not defined.