### PR TITLE
Removed inappropriate $! reference in Net::FTP

### DIFF
--- a/lib/net/ftp.rb
+++ b/lib/net/ftp.rb
@@ -577,8 +577,9 @@ module Net
           if !resp.start_with?("1")
             raise FTPReplyError, resp
           end
-        ensure
-          conn.close if conn && $!
+        rescue
+          conn&.close
+          raise
         end
       else
         sock = makeport


### PR DESCRIPTION
`$!` in ensure section may be an Exception object that already exists before entering its `begin`...`end`. 
`Net::FTP#transfercmd` uses `$!` for error handling, so using `Net::FTP` in rescue section will cause an unexpected data connection drop. Since an exceptions is required to decide to close the data connection, it should be placed in rescue section.

The reproduction code is as follows:

```ruby
require "net/ftp"

begin
  raise "FOO!"
rescue
  ftp = Net::FTP.new("ftp.example.com")  # specify an anonymous FTP server
  ftp.login
  p ftp.list
end
```
result:

```console
$ ruby ftp-err.rb
/home/gotoyuzo/.rbenv/versions/3.2.2/lib/ruby/3.2.0/socket.rb:456:in `__read_nonblock': closed stream (IOError)
        from /home/gotoyuzo/.rbenv/versions/3.2.2/lib/ruby/3.2.0/socket.rb:456:in `read_nonblock'
        from /home/gotoyuzo/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/net-protocol-0.2.2/lib/net/protocol.rb:218:in `rbuf_fill'
        from /home/gotoyuzo/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/net-protocol-0.2.2/lib/net/protocol.rb:199:in `readuntil'
        from /home/gotoyuzo/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/net-ftp-0.2.0/lib/net/ftp.rb:1510:in `gets'
        from /home/gotoyuzo/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/net-ftp-0.2.0/lib/net/ftp.rb:690:in `block (2 levels) in retrlines'
        from /home/gotoyuzo/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/net-ftp-0.2.0/lib/net/ftp.rb:335:in `with_binary'
        from /home/gotoyuzo/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/net-ftp-0.2.0/lib/net/ftp.rb:687:in `block in retrlines'
        from /home/gotoyuzo/.rbenv/versions/3.2.2/lib/ruby/3.2.0/monitor.rb:202:in `synchronize'
        from /home/gotoyuzo/.rbenv/versions/3.2.2/lib/ruby/3.2.0/monitor.rb:202:in `mon_synchronize'
        from /home/gotoyuzo/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/net-ftp-0.2.0/lib/net/ftp.rb:686:in `retrlines'
        from /home/gotoyuzo/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/net-ftp-0.2.0/lib/net/ftp.rb:944:in `list'
        from ftp-err.rb:8:in `rescue in <main>'
        from ftp-err.rb:3:in `<main>'
ftp-err.rb:4:in `<main>': FOO! (RuntimeError)
```