### PR TITLE
Fix connection leak when non-StandardError exceptions raise

### DIFF
--- a/lib/net/ftp.rb
+++ b/lib/net/ftp.rb
@@ -577,7 +577,7 @@ module Net
           if !resp.start_with?("1")
             raise FTPReplyError, resp
           end
-        rescue
+        rescue Exception
           conn&.close
           raise
         end


### PR DESCRIPTION
Thanks, @jeremyevans!
https://github.com/ruby/net-ftp/pull/24#issuecomment-1855259150