### PR TITLE
Prefer String#each_line in Net::FTP#features

### DIFF
--- a/lib/net/ftp.rb
+++ b/lib/net/ftp.rb
@@ -1343,7 +1343,7 @@ module Net
       end
 
       feats = []
-      resp.split("\n").each do |line|
+      resp.each_line do |line|
         next if !line.start_with?(' ') # skip status lines
 
         feats << line.strip


### PR DESCRIPTION
``String#split`` without a block creates an intermediate array and requires a call to ``Array#each`` to iterate.
Replace ``String#split("\n").each`` with ``String#each_line``, which is more efficient and readable.