### PR TITLE
Don't use OpenSSL session cache on JRuby

### DIFF
--- a/lib/net/ftp.rb
+++ b/lib/net/ftp.rb
@@ -249,10 +249,15 @@ module Net
         if defined?(VerifyCallbackProc)
           @ssl_context.verify_callback = VerifyCallbackProc
         end
-        @ssl_context.session_cache_mode =
-          OpenSSL::SSL::SSLContext::SESSION_CACHE_CLIENT |
-          OpenSSL::SSL::SSLContext::SESSION_CACHE_NO_INTERNAL_STORE
-        @ssl_context.session_new_cb = proc {|sock, sess| @ssl_session = sess }
+
+        # jruby-openssl does not support session caching
+        unless RUBY_ENGINE == "jruby"
+          @ssl_context.session_cache_mode =
+            OpenSSL::SSL::SSLContext::SESSION_CACHE_CLIENT |
+            OpenSSL::SSL::SSLContext::SESSION_CACHE_NO_INTERNAL_STORE
+          @ssl_context.session_new_cb = proc {|sock, sess| @ssl_session = sess }
+        end
+
         @ssl_session = nil
         if options[:private_data_connection].nil?
           @private_data_connection = true

--- a/test/net/ftp/test_ftp.rb
+++ b/test/net/ftp/test_ftp.rb
@@ -1953,7 +1953,7 @@ EOF
         assert_equal(nil, commands.shift)
         # FIXME: The new_session_cb is known broken for clients in OpenSSL 1.1.0h.
         # See https://github.com/openssl/openssl/pull/5967 for details.
-        if OpenSSL::OPENSSL_LIBRARY_VERSION !~ /OpenSSL 1.1.0h|LibreSSL/
+        if RUBY_ENGINE != "jruby" && OpenSSL::OPENSSL_LIBRARY_VERSION !~ /OpenSSL 1.1.0h|LibreSSL/
           assert_equal(true, session_reused_for_data_connection)
         end
       ensure


### PR DESCRIPTION
JRuby's implementation of the `openssl` library does not support session caching, so this results in errors and prevents the library from working.

With the given patch all but one test pass on JRuby.

See https://github.com/jruby/jruby/issues/6682#issuecomment-2188222567